### PR TITLE
Use snakemake checkpoints for single command

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3,6 +3,7 @@ import os
 from glob import glob
 import pandas as pd
 import numpy as np
+from snakemake.logging import logger
 
 configfile: 'config.yml'
 SCRIPT_DIR = srcdir('scripts')

--- a/Snakefile
+++ b/Snakefile
@@ -47,6 +47,17 @@ DTR_READS_FASTA              = '{}.dtr.fasta'.format(str(DTR_READS_PREFIX))
 DTR_READS_STATS              = '{}.dtr.stats.tsv'.format(str(DTR_READS_PREFIX))
 DTR_READS_HIST               = '{}.dtr.hist.png'.format(str(DTR_READS_PREFIX))
 
+###################################
+# VIRSORTER FILES                 #
+###################################
+VIRSORTER_DIR            = OUTPUT_ROOT / SAMPLE / STYPE / VERSION / 'virsorter'
+VIRSORTER_FASTA          = VIRSORTER_DIR / 'all_phage.fasta'
+
+pre_filter = config['pre_filter'].upper()
+FILTERED_FASTA = VIRSORTER_FASTA if pre_filter == "VIRSORTER" \
+                                 else DTR_READS_FASTA if pre_filter == "DTR" \
+                                 else READS_IMPORT_FASTA
+
 
 ###################################
 # KAIJU CLASSIFICATION            #
@@ -184,6 +195,7 @@ wildcard_constraints:
 
 include: 'rules/summary.smk'
 include: 'rules/dtr_reads.smk'
+include: 'rules/virsorter.smk'
 include: 'rules/kaiju.smk'
 include: 'rules/kmer_bins.smk'
 include: 'rules/align_clusters.smk'

--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,7 @@
 from pathlib import Path
 import os
 from glob import glob
+import pandas as pd
 
 configfile: 'config.yml'
 SCRIPT_DIR = srcdir('scripts')
@@ -34,7 +35,7 @@ READS_IMPORT_SUMMARY    = config['input_summary']
 # SUMMARY STATS FILES             #
 ###################################
 READS_DIR      = OUTPUT_ROOT / SAMPLE / STYPE / VERSION / 'reads_summary'
-SUMMARY_PLOT   = str(READS_DIR / 'reads.summary.stats.png')
+SUMMARY_PLOT   = READS_DIR / 'reads.summary.stats.png'
 
 
 ###################################
@@ -53,7 +54,7 @@ DTR_READS_HIST               = '{}.dtr.hist.png'.format(str(DTR_READS_PREFIX))
 VIRSORTER_DIR            = OUTPUT_ROOT / SAMPLE / STYPE / VERSION / 'virsorter'
 VIRSORTER_FASTA          = VIRSORTER_DIR / 'all_phage.fasta'
 
-pre_filter = config['pre_filter'].upper()
+pre_filter = config.get('pre_filter', 'DTR').upper()
 FILTERED_FASTA = VIRSORTER_FASTA if pre_filter == "VIRSORTER" \
                                  else DTR_READS_FASTA if pre_filter == "DTR" \
                                  else READS_IMPORT_FASTA
@@ -63,67 +64,66 @@ FILTERED_FASTA = VIRSORTER_FASTA if pre_filter == "VIRSORTER" \
 # KAIJU CLASSIFICATION            #
 ###################################
 KAIJU_DIR                 = OUTPUT_ROOT /  SAMPLE / STYPE / VERSION / 'kaiju'
-KAIJU_RESULTS             = str(KAIJU_DIR / 'results.tsv')
-KAIJU_RESULTS_TAXA        = str(KAIJU_DIR / 'results.taxa.tsv')
-KAIJU_RESULTS_KRONA       = str(KAIJU_DIR / 'results.krona')
-KAIJU_RESULTS_KRONA_HTML  = str(KAIJU_DIR / 'results.html')
-KAIJU_TAXIDS              = str(KAIJU_DIR / 'taxids.csv')
-KAIJU_TAXINFO             = str(KAIJU_DIR / 'taxinfo.csv')
-KAIJU_TAX_GENOMESIZE_EST  = str(KAIJU_DIR / 'taxid_genomesize_estimates.csv')
+KAIJU_RESULTS             = KAIJU_DIR / 'results.tsv'
+KAIJU_RESULTS_TAXA        = KAIJU_DIR / 'results.taxa.tsv'
+KAIJU_RESULTS_KRONA       = KAIJU_DIR / 'results.krona'
+KAIJU_RESULTS_KRONA_HTML  = KAIJU_DIR / 'results.html'
+KAIJU_TAXIDS              = KAIJU_DIR / 'taxids.csv'
+KAIJU_TAXINFO             = KAIJU_DIR / 'taxinfo.csv'
+KAIJU_TAX_GENOMESIZE_EST  = KAIJU_DIR / 'taxid_genomesize_estimates.csv'
 
 
 ###################################
 # K-mer UAMP files and plots      #
 ###################################
 KMER_BIN_ROOT                     = OUTPUT_ROOT /  SAMPLE / STYPE / VERSION / 'kmer_binning'
-KMER_BINS_MEMBERSHIP              = str(KMER_BIN_ROOT / 'bin_membership.tsv')
-KMER_BIN_STATS                    = str(KMER_BIN_ROOT / 'bin_stats.csv')
-KMER_FREQS_TMP                    = str(KMER_BIN_ROOT / 'kmer_comp.tmp')
-KMER_FREQS                        = str(KMER_BIN_ROOT / 'kmer_comp.tsv')
-KMER_FREQS_UMAP                   = str(KMER_BIN_ROOT / 'kmer_comp.umap.tsv')
-KMER_FREQS_UMAP_TAX               = str(KMER_BIN_ROOT / ('kmer_comp.umap.{database}.{rank}.png'))
-KMER_FREQS_UMAP_QSCORE            = str(KMER_BIN_ROOT / 'kmer_comp.umap.qscore.png')
-KMER_FREQS_UMAP_GC                = str(KMER_BIN_ROOT / 'kmer_comp.umap.gc.png')
-KMER_FREQS_UMAP_READLENGTH        = str(KMER_BIN_ROOT / 'kmer_comp.umap.readlength.png')
-KMER_FREQS_UMAP_BINS_PLOT         = str(KMER_BIN_ROOT / 'kmer_comp.umap.bins.png')
-KMER_FREQS_UMAP_BINS_COORDS       = str(KMER_BIN_ROOT / 'kmer_comp.umap.bins.tsv')
+KMER_BINS_MEMBERSHIP              = KMER_BIN_ROOT / 'bin_membership.tsv'
+KMER_BINS_LIST                    = KMER_BIN_ROOT / 'bin_list.txt'
+KMER_BIN_STATS                    = KMER_BIN_ROOT / 'bin_stats.csv'
+KMER_FREQS_TMP                    = KMER_BIN_ROOT / 'kmer_comp.tmp'
+KMER_FREQS                        = KMER_BIN_ROOT / 'kmer_comp.tsv'
+KMER_FREQS_UMAP                   = KMER_BIN_ROOT / 'kmer_comp.umap.tsv'
+KMER_FREQS_UMAP_TAX               = KMER_BIN_ROOT / 'kmer_comp.umap.{database}.{rank}.png'
+KMER_FREQS_UMAP_QSCORE            = KMER_BIN_ROOT / 'kmer_comp.umap.qscore.png'
+KMER_FREQS_UMAP_GC                = KMER_BIN_ROOT / 'kmer_comp.umap.gc.png'
+KMER_FREQS_UMAP_READLENGTH        = KMER_BIN_ROOT / 'kmer_comp.umap.readlength.png'
+KMER_FREQS_UMAP_BINS_PLOT         = KMER_BIN_ROOT / 'kmer_comp.umap.bins.png'
+KMER_FREQS_UMAP_BINS_COORDS       = KMER_BIN_ROOT / 'kmer_comp.umap.bins.tsv'
 
 
 ###################################
 # BIN ANALYSIS FILES              #
 ###################################
 BINS_DIR                    = KMER_BIN_ROOT / 'bins'
-BIN_READLIST                = str(BINS_DIR / '{bin_id}' / 'read_list.txt')
-BIN_FASTA                   = str(BINS_DIR / '{bin_id}' / '{bin_id}.reads.fa')
-BIN_GENOME_SIZE             = str(BINS_DIR / '{bin_id}' / 'genome_size.txt')
-ALL_BIN_IDS                 = list(map(lambda x: x.split('/')[-1], glob(str(BINS_DIR)+'/*')))
+BIN_READLIST                = BINS_DIR / '{bin_id}' / 'read_list.txt'
+BIN_FASTA                   = BINS_DIR / '{bin_id}' / '{bin_id}.reads.fa'
+BIN_GENOME_SIZE             = BINS_DIR / '{bin_id}' / 'genome_size.txt'
 SKIP_BINS                   = config['SKIP_BINS'][SAMPLE][STYPE][VERSION]
-BIN_IDS                     = [b for b in ALL_BIN_IDS if int(b) not in SKIP_BINS]
 BINNED_ANALYSIS_ROOT        = KMER_BIN_ROOT / "refine_bins"
 
 #####################################
 # Alignment clustering  FILES       #
 #####################################
 ALN_CLUST_DIR            = BINNED_ANALYSIS_ROOT / 'alignments'
-ALN_CLUST_PAF            = str(ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.ava.paf')
-ALN_CLUST_OUTPUT_PREFIX  = str(ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.clust')
-ALN_CLUST_OUTPUT_HEATMAP = str(ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.clust.heatmap.png')
-ALN_CLUST_OUTPUT_INFO    = str(ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.clust.info.csv')
-ALN_CLUST_READS_COMBO    = str(ALN_CLUST_DIR / 'all_bins.clust.info.csv')
+ALN_CLUST_PAF            = ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.ava.paf'
+ALN_CLUST_OUTPUT_PREFIX  = ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.clust'
+ALN_CLUST_OUTPUT_HEATMAP = ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.clust.heatmap.png'
+ALN_CLUST_OUTPUT_INFO    = ALN_CLUST_DIR / '{bin_id}' / '{bin_id}.clust.info.csv'
+ALN_CLUST_READS_COMBO    = ALN_CLUST_DIR / 'all_bins.clust.info.csv'
 
 
 ###################################
 # Separate cluster-specific reads #
 ###################################
 BIN_CLUSTER_DIR                 = BINNED_ANALYSIS_ROOT / 'align_cluster_reads'
-BIN_CLUSTER_READS_INFO          = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.readinfo.csv')
-BIN_CLUSTER_READS_LIST          = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.readlist.csv')
-BIN_CLUSTER_READS_FASTA         = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.reads.fasta')
-BIN_CLUSTER_REF_READ_LIST       = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_readlist.csv')
-BIN_CLUSTER_POL_READS_LIST      = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.pol_readlist.csv')
-BIN_CLUSTER_REF_READ_FASTA      = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.fa')
-BIN_CLUSTER_POL_READS_FASTQ     = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.pol_reads.fq')
-BIN_CLUSTER_POL_READS_FASTA     = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.pol_reads.fa')
+BIN_CLUSTER_READS_INFO          = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.readinfo.csv'
+BIN_CLUSTER_READS_LIST          = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.readlist.csv'
+BIN_CLUSTER_READS_FASTA         = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.reads.fasta'
+BIN_CLUSTER_REF_READ_LIST       = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_readlist.csv'
+BIN_CLUSTER_POL_READS_LIST      = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.pol_readlist.csv'
+BIN_CLUSTER_REF_READ_FASTA      = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.fa'
+BIN_CLUSTER_POL_READS_FASTQ     = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.pol_reads.fq'
+BIN_CLUSTER_POL_READS_FASTA     = BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin_clust_id}.pol_reads.fa'
 
 
 ####################################
@@ -131,22 +131,21 @@ BIN_CLUSTER_POL_READS_FASTA     = str(BIN_CLUSTER_DIR / '{bin_clust_id}' / '{bin
 ####################################
 POLISH_DIR                       = BINNED_ANALYSIS_ROOT / 'align_cluster_polishing'
 RACON_DIR                        = POLISH_DIR / 'racon'
-BIN_CLUSTER_RACON_POLISHED_FASTA = str(RACON_DIR / '{bin_clust_id}' / '{{bin_clust_id}}.ref_read.racon_{repeats}x.fasta'.format(repeats=RACON_ROUNDS))
+BIN_CLUSTER_RACON_POLISHED_FASTA = RACON_DIR / '{bin_clust_id}' / '{{bin_clust_id}}.ref_read.racon_{repeats}x.fasta'.format(repeats=RACON_ROUNDS)
 
 
 #####################################
 # Polish cluster reads using Medaka #
 #####################################
 MEDAKA_DIR                                    = POLISH_DIR / 'medaka'
-BIN_CLUSTER_POLISHED_REF_TMP                  = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.tmp.fasta')
-BIN_CLUSTER_POLISHED_REF                      = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.fasta')
-BIN_CLUSTER_POLISHED_POL_VS_REF_PAF           = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.paf')
-BIN_CLUSTER_POLISHED_POL_VS_REF_STRANDS       = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.strands.summary.tsv')
-BIN_CLUSTER_POLISHED_POL_VS_REF_STRAND_ANNOTS = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.strands.reads.tsv')
-BIN_CLUSTER_POLISHED_REF_PRODIGAL             = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.prodigal.cds.fasta')
-BIN_CLUSTER_POLISHED_REF_PRODIGAL_TXT         = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.prodigal.cds.txt')
-BIN_CLUSTER_POLISHED_REF_PRODIGAL_STATS       = str(MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.prodigal.cds.stats.txt')
-
+BIN_CLUSTER_POLISHED_REF_TMP                  = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.tmp.fasta'
+BIN_CLUSTER_POLISHED_REF                      = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.fasta'
+BIN_CLUSTER_POLISHED_POL_VS_REF_PAF           = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.paf'
+BIN_CLUSTER_POLISHED_POL_VS_REF_STRANDS       = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.strands.summary.tsv'
+BIN_CLUSTER_POLISHED_POL_VS_REF_STRAND_ANNOTS = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.strands.reads.tsv'
+BIN_CLUSTER_POLISHED_REF_PRODIGAL             = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.prodigal.cds.fasta'
+BIN_CLUSTER_POLISHED_REF_PRODIGAL_TXT         = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.prodigal.cds.txt'
+BIN_CLUSTER_POLISHED_REF_PRODIGAL_STATS       = MEDAKA_DIR / '{bin_clust_id}' / '{bin_clust_id}.ref_read.medaka.prodigal.cds.stats.txt'
 
 #########################################
 # Check for fixed or cyclic permutation #
@@ -156,6 +155,23 @@ DTR_ALIGN_COORD_PLOT             = '{}.dtr.aligns.png'.format(DTR_ALIGN_PREFIX)
 DTR_ALIGN_TSV                    = '{}.dtr.aligns.tsv'.format(DTR_ALIGN_PREFIX)
 DTR_ALIGN_CYC_PERM_TSV           = str(POLISH_DIR / 'polished.cyclic_permut.stats.tsv')
 
+# List of templates to exapand for the all_polish_and_annotate rule
+POLISHED_TEMPLATE_LIST = [ \
+    BIN_CLUSTER_READS_INFO, \
+    BIN_CLUSTER_READS_LIST, \
+    BIN_CLUSTER_REF_READ_LIST, \
+    BIN_CLUSTER_REF_READ_FASTA, \
+    BIN_CLUSTER_POL_READS_LIST, \
+    BIN_CLUSTER_POL_READS_FASTA, \
+    BIN_CLUSTER_RACON_POLISHED_FASTA, \
+    BIN_CLUSTER_POLISHED_REF, \
+    DTR_ALIGN_COORD_PLOT, \
+    BIN_CLUSTER_POLISHED_REF_PRODIGAL, \
+    BIN_CLUSTER_POLISHED_REF_PRODIGAL_TXT, \
+    BIN_CLUSTER_POLISHED_REF_PRODIGAL_STATS, \
+    BIN_CLUSTER_POLISHED_POL_VS_REF_STRANDS, \
+    BIN_CLUSTER_POLISHED_POL_VS_REF_STRAND_ANNOTS, \
+]
 
 ######################################
 # Combine Medaka polished references #
@@ -229,35 +245,25 @@ rule all_kmer_count_and_bin:
 rule all_kaiju:
     input:
         KAIJU_RESULTS_KRONA_HTML,
-        expand(KMER_FREQS_UMAP_TAX, database=DATABASE_NAME, rank=TAX_RANK),
+        expand(str(KMER_FREQS_UMAP_TAX), database=DATABASE_NAME, rank=TAX_RANK),
 
 rule all_populate_kmer_bins:
-    input: dynamic(BIN_READLIST),
-           dynamic(BIN_FASTA),
+    input:
+        bin_reads=lambda w: expand(str(BIN_READLIST), bin_id=get_kmer_bins_all(w)),
+        bin_fasta=lambda w: expand(str(BIN_FASTA), bin_id=get_kmer_bins_all(w)),
 
 rule all_alignment_clusters:
     input:
-        KMER_BIN_STATS,
-        expand(ALN_CLUST_OUTPUT_HEATMAP, bin_id=BIN_IDS),
-        expand(ALN_CLUST_OUTPUT_INFO, bin_id=BIN_IDS),
+        stats=KMER_BIN_STATS,
+        heatmaps=lambda w: expand(str(ALN_CLUST_OUTPUT_HEATMAP), \
+                                  bin_id=get_kmer_bins_good(w)),
+        align=lambda w: expand(str(ALN_CLUST_OUTPUT_INFO), \
+                               bin_id=get_kmer_bins_good(w)),
 
 rule all_polish_and_annotate:
     input:
         ALN_CLUST_READS_COMBO,
-        dynamic(BIN_CLUSTER_READS_INFO),
-        dynamic(BIN_CLUSTER_READS_LIST),
-        dynamic(BIN_CLUSTER_REF_READ_LIST),
-        dynamic(BIN_CLUSTER_REF_READ_FASTA),
-        dynamic(BIN_CLUSTER_POL_READS_LIST),
-        dynamic(BIN_CLUSTER_POL_READS_FASTA),
-        dynamic(BIN_CLUSTER_RACON_POLISHED_FASTA),
-        dynamic(BIN_CLUSTER_POLISHED_REF),
-        dynamic(DTR_ALIGN_COORD_PLOT),
-        dynamic(BIN_CLUSTER_POLISHED_REF_PRODIGAL),
-        dynamic(BIN_CLUSTER_POLISHED_REF_PRODIGAL_TXT),
-        dynamic(BIN_CLUSTER_POLISHED_REF_PRODIGAL_STATS),
-        dynamic(BIN_CLUSTER_POLISHED_POL_VS_REF_STRANDS),
-        dynamic(BIN_CLUSTER_POLISHED_POL_VS_REF_STRAND_ANNOTS),
+        get_polished_bin_outputs,  # expands all of POLISHED_TEMPALTE_LIST
 
 rule all_combine_dedup_summarize:
     input:

--- a/Snakefile
+++ b/Snakefile
@@ -2,6 +2,7 @@ from pathlib import Path
 import os
 from glob import glob
 import pandas as pd
+import numpy as np
 
 configfile: 'config.yml'
 SCRIPT_DIR = srcdir('scripts')
@@ -119,7 +120,7 @@ ALN_CLUST_READS_COMBO    = ALN_CLUST_DIR / 'all_bins.clust.info.csv'
 BIN_CLUSTER_ROOT                = BINNED_ANALYSIS_ROOT / 'align_cluster_reads'
 BIN_CLUSTER_DIR                 = BIN_CLUSTER_ROOT / '{bin_clust_id}'
 BIN_CLUSTER_READS_INFO          = BIN_CLUSTER_DIR / '{bin_clust_id}.readinfo.csv'
-BIN_CLUSTER_READS_LIST          = BIN_CLUSTER_DIR / '{bin_clust_id}.readlist.csv'
+BIN_CLUSTER_READS_LIST          = BIN_CLUSTER_DIR / 'readlist.csv'
 BIN_CLUSTER_READS_FASTA         = BIN_CLUSTER_DIR / '{bin_clust_id}.reads.fasta'
 BIN_CLUSTER_REF_READ_LIST       = BIN_CLUSTER_DIR / '{bin_clust_id}.ref_readlist.csv'
 BIN_CLUSTER_POL_READS_LIST      = BIN_CLUSTER_DIR / '{bin_clust_id}.pol_readlist.csv'

--- a/Snakefile
+++ b/Snakefile
@@ -155,18 +155,11 @@ DTR_ALIGN_COORD_PLOT             = '{}.dtr.aligns.png'.format(DTR_ALIGN_PREFIX)
 DTR_ALIGN_TSV                    = '{}.dtr.aligns.tsv'.format(DTR_ALIGN_PREFIX)
 DTR_ALIGN_CYC_PERM_TSV           = str(POLISH_DIR / 'polished.cyclic_permut.stats.tsv')
 
-# List of templates to exapand for the all_polish_and_annotate rule
-POLISHED_TEMPLATE_LIST = [ \
-    BIN_CLUSTER_READS_INFO, \
-    BIN_CLUSTER_READS_LIST, \
-    BIN_CLUSTER_REF_READ_LIST, \
+# List of templates to exapand for final targets
+POLISHED_TEMPLATE_TARGET_LIST = [ \
     BIN_CLUSTER_REF_READ_FASTA, \
-    BIN_CLUSTER_POL_READS_LIST, \
     BIN_CLUSTER_POL_READS_FASTA, \
-    BIN_CLUSTER_RACON_POLISHED_FASTA, \
-    BIN_CLUSTER_POLISHED_REF, \
     DTR_ALIGN_COORD_PLOT, \
-    BIN_CLUSTER_POLISHED_REF_PRODIGAL, \
     BIN_CLUSTER_POLISHED_REF_PRODIGAL_TXT, \
     BIN_CLUSTER_POLISHED_REF_PRODIGAL_STATS, \
     BIN_CLUSTER_POLISHED_POL_VS_REF_STRANDS, \
@@ -234,6 +227,29 @@ include: 'rules/linear_concats.smk'
 # 6. all_combine_dedup_summarize
 # 7. all_linear_concatemer_reads
 
+rule all:
+    input:
+        SUMMARY_PLOT,
+        KMER_FREQS_UMAP_QSCORE,
+        KMER_FREQS_UMAP_GC,
+        KMER_FREQS_UMAP_READLENGTH,
+        KMER_FREQS_UMAP_BINS_PLOT,
+        KAIJU_RESULTS_KRONA_HTML,
+        expand(str(KMER_FREQS_UMAP_TAX), database=DATABASE_NAME, rank=TAX_RANK),
+        KMER_BIN_STATS,
+        lambda w: expand(str(ALN_CLUST_OUTPUT_HEATMAP), \
+                         bin_id=get_kmer_bins_good(w)),
+        ALN_CLUST_READS_COMBO,
+        get_polished_bin_outputs,  # expands all of POLISHED_TEMPLATE_TARGET_LIST
+                                   # (see rules/align_clusters.smk)
+        ALL_POL_CDS_PLOT_UNIQ_ALL,
+        ALL_POL_CDS_PLOT_UNIQ_DTR_NPOL10,
+        ALL_POL,
+        ALL_POL_UNIQ,
+        ALL_POL_STATS
+
+## The orignal pieces
+
 rule all_kmer_count_and_bin:
     input:
         SUMMARY_PLOT,
@@ -277,3 +293,4 @@ rule all_linear_concatemer_reads:
     input:
         CONCATEMER_READ_COPY_REPEATS_CONTOURS,
         CONCATEMER_READ_FASTA,
+

--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,7 @@ input_summary: /media/sfodata/users/jbeaulaurier/projects/packages/DTR-phage-pip
 output_root: /media/sfodata/users/jbeaulaurier/projects/packages/DTR-phage-pipeline/analysis/
 
 max_threads: 32 # Maximum number of threads the pipeline will attempt to use
+pre_filter: DTR # Only process reads with DTR (None: all reads, Virsorter: virsorter)
 
 # Medaka model depends on whether MinION or PromethION used for sequencing and which Guppy version
 # was used for basecalling. Please see Medaka documentation for list of available models.
@@ -43,6 +44,14 @@ SKIP_BINS:
 DTR_FIND:
     ovlp: 20 # Percent of read start/end to check for alignment
     chunksize: 5000
+
+VIRSORTER:
+    db: 1             # Either "1" (DEFAULT Refseqdb) or "2" (Viromedb)
+    diamond: True     # False: blastp, True: diamond
+    virome: False     # True: input is a virome, don't train on data
+    prophage: False   # False: only use phage, True: use prohpage, too
+    data_dir: '/mnt/arginine/galaxydata/seqdbs/virsorter-data'
+                      # location of virsorter-data
 
 KMER_CALC:
     k: 5      # k-mer size to use for k-mer binning

--- a/environment.yml
+++ b/environment.yml
@@ -3,10 +3,9 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python == 3.7
-  - snakemake < 5.4.0
+  - python >= 3.7
+  - snakemake >= 5.14.0
   - matplotlib
   - click
   - pandas
   - requests
-  - minimap2==2.17

--- a/envs/virsorter.yml
+++ b/envs/virsorter.yml
@@ -1,0 +1,5 @@
+channels:
+ - conda-forge
+ - bioconda 
+dependencies:
+ - virsorter=1.0.6

--- a/rules/align_clusters.smk
+++ b/rules/align_clusters.smk
@@ -53,7 +53,7 @@ checkpoint create_bin_cluster_read_lists:
         # parse table; filter by cluster
         for clust_info_file in input.clust_info:
             bin_id = os.path.basename(os.path.dirname(clust_info_file))
-            print(f"DEBUG: bin id: {bin_id}")
+            logger.debug(f"DEBUG: bin id: {bin_id}")
             df = pd.read_csv(clust_info_file)
             for clust_id, df_clust in df.groupby('cluster'):
                 bin_clust_id = f"{bin_id}_{clust_id}"
@@ -75,7 +75,7 @@ def expand_template_from_bin_clusters(wildcards, template):
                                                 "{bin_clust_id}", \
                                                 "readlist.csv"))
 
-    print(f"DEBUG: clusters: {repr(bin_clusters)}")
+    logger.debug(f"DEBUG: clusters: {repr(bin_clusters)}")
     # expand template
     return expand(str(template), bin_clust_id=bin_clusters)
 

--- a/rules/align_clusters.smk
+++ b/rules/align_clusters.smk
@@ -70,7 +70,7 @@ rule create_bin_cluster_read_lists:
 rule get_cluster_reads_fasta:
     input: 
         clustreads=BIN_CLUSTER_READS_LIST,
-        allfasta=DTR_READS_FASTA
+        allfasta=FILTERED_FASTA
     output: BIN_CLUSTER_READS_FASTA
     conda: '../envs/seqkit.yml'
     shell:
@@ -94,7 +94,7 @@ rule select_read_with_longest_DTR:
 rule create_bin_cluster_ref_fasta:
     input: 
         readlist=BIN_CLUSTER_REF_READ_LIST,
-        fasta=DTR_READS_FASTA,
+        fasta=FILTERED_FASTA,
     output: BIN_CLUSTER_REF_READ_FASTA
     conda: '../envs/seqkit.yml'
     shell:
@@ -103,7 +103,7 @@ rule create_bin_cluster_ref_fasta:
 rule create_bin_cluster_pol_fastqs:
     input: 
         readlist=BIN_CLUSTER_POL_READS_LIST,
-        fasta=DTR_READS_FASTA,
+        fasta=FILTERED_FASTA,
     output: BIN_CLUSTER_POL_READS_FASTA
     conda: '../envs/seqkit.yml'
     shell:

--- a/rules/align_clusters.smk
+++ b/rules/align_clusters.smk
@@ -52,7 +52,11 @@ def get_bin_clusters(wildcards):
                              .groupby(['bin_id', 'cluster']) \
                              .groups]
 
-def get_polished_bin_outputs(wildcards, templates=POLISHED_TEMPLATE_LIST):
+def get_polished_bin_outputs(wildcards, \
+                             templates=POLISHED_TEMPLATE_TARGET_LIST):
+    """ Take targets defined in Snakefile as templates on bin_clust_id
+    and return list of final target files using list of bin_clust_ids
+    """
     bin_output_list = []
     final_bin_list = get_bin_clusters(wildcards)
     for filename_template in templates:

--- a/rules/annotate.smk
+++ b/rules/annotate.smk
@@ -46,10 +46,7 @@ rule parse_align_clust_strands_paf:
         counts=BIN_CLUSTER_POLISHED_POL_VS_REF_STRANDS,
         annots=BIN_CLUSTER_POLISHED_POL_VS_REF_STRAND_ANNOTS
     run:
-        import os
-        import re
-        import pandas as pd
-        clust_id = os.path.basename(input.paf).split('.')[0]
+        clust_id = wildcards.bin_clust_id
         cols = ['qname', 'qlen', 'qstart', 'qend', 'strand', 'tname', \
                 'tlen', 'tstart', 'tend', 'matches', 'alnlen', 'mapqv']
         paf   = pd.read_csv(input.paf, sep='\t', header=None, usecols=list(range(12)), names=cols)

--- a/rules/dedup.smk
+++ b/rules/dedup.smk
@@ -42,8 +42,6 @@ rule plot_all_prodigal_stats:
     output:
         plot1=ALL_POL_CDS_PLOT_UNIQ_ALL,
         plot2=ALL_POL_CDS_PLOT_UNIQ_DTR_NPOL10,
-    params:
-        pol_dir=MEDAKA_DIR
     conda: '../envs/clustering.yml'
     shell:
         'python {SCRIPT_DIR}/plot_cds_summaries.py --output1={output.plot1} '

--- a/rules/dtr_align.smk
+++ b/rules/dtr_align.smk
@@ -4,16 +4,16 @@
 
 rule align_dtr_seqs_to_polished_refs:
     input: 
-        ref = BIN_CLUSTER_POLISHED_REF
+        ref = BIN_CLUSTER_POLISHED_REF,
+        binsdir = BINS_ROOT
     output: 
         plot = DTR_ALIGN_COORD_PLOT,
         tsv = DTR_ALIGN_TSV
     params: 
         prefix = DTR_ALIGN_PREFIX,
-        binsdir = BINS_DIR,
         ovlp = config['DTR_ALIGN']['ovlp']
     conda: '../envs/plot-umap.yml'
     threads: config['DTR_ALIGN']['threads']
     shell:
         'python {SCRIPT_DIR}/plot_headful_dtr_positions.py -t {threads} -p {params.prefix} '
-        '-o {params.ovlp} {params.binsdir} {input.ref}'
+        '-o {params.ovlp} {input.binsdir} {input.ref}'

--- a/rules/kaiju.smk
+++ b/rules/kaiju.smk
@@ -3,7 +3,7 @@
 ####################################################################################
 
 rule kaiju:
-    input: DTR_READS_FASTA
+    input: FILTERED_FASTA
     output: KAIJU_RESULTS
     conda: '../envs/kaiju.yml'
     threads: config['max_threads']

--- a/rules/kmer_bins.smk
+++ b/rules/kmer_bins.smk
@@ -3,7 +3,7 @@
 #################################
 
 rule calc_kmer_freq:
-    input: DTR_READS_FASTA
+    input: FILTERED_FASTA
     output: temp(KMER_FREQS_TMP)
     conda: '../envs/python.yml'
     params: 
@@ -55,7 +55,7 @@ rule label_umap_freq_map_with_qscore:
 rule label_umap_freq_map_with_gc_content:
     input: 
         umap = KMER_FREQS_UMAP,
-        fasta = DTR_READS_FASTA
+        fasta = FILTERED_FASTA
     output: KMER_FREQS_UMAP_GC
     params:
         size = config['UMAP']['scatter_size'],
@@ -68,7 +68,7 @@ rule label_umap_freq_map_with_gc_content:
 rule label_umap_freq_map_with_readlength:
     input: 
         umap = KMER_FREQS_UMAP,
-        fastx = DTR_READS_FASTA
+        fastx = FILTERED_FASTA
     output: KMER_FREQS_UMAP_READLENGTH
     params:
         min_rl=config['UMAP']['min_rl'],
@@ -139,7 +139,7 @@ rule create_kmer_bins:
 rule kmer_binned_fasta:
     input:
         read_list=BIN_READLIST,
-        reads_fasta=DTR_READS_FASTA,
+        reads_fasta=FILTERED_FASTA,
     output: BIN_FASTA
     conda: '../envs/seqkit.yml'
     shell:

--- a/rules/kmer_bins.smk
+++ b/rules/kmer_bins.smk
@@ -178,7 +178,7 @@ def expand_template_from_bins(wildcards, template):
     # get dir through checkpoints to throw Exception if checkpoint is pending
     checkpoint_dir = checkpoints.generate_bins_and_stats.get(**wildcards).output
     # get bins from files
-    bins, _bins = glob_wildcards(BIN_READLIST)
+    bins, = glob_wildcards(BIN_READLIST)
     # skips from config
     bins = [b for b in bins if b not in SKIP_BINS]
     # expand template

--- a/rules/polish.smk
+++ b/rules/polish.smk
@@ -28,7 +28,7 @@ rule run_medaka:
         draft=BIN_CLUSTER_RACON_POLISHED_FASTA
     output: temp(BIN_CLUSTER_POLISHED_REF_TMP)
     params:
-        out_dir=lambda x: str(Path(BIN_CLUSTER_POLISHED_REF_TMP.format(**x)).parent),
+        out_dir=lambda x: str(Path(str(BIN_CLUSTER_POLISHED_REF_TMP).format(**x)).parent),
         model=config['MEDAKA']['model']
     threads: config['MEDAKA']['threads']
     conda: '../envs/medaka-0.11.0.yml'
@@ -39,11 +39,13 @@ rule run_medaka:
 
 rule rename_polished_ref_reads:
     input:
-        fasta = BIN_CLUSTER_POLISHED_REF_TMP,
+        fasta=BIN_CLUSTER_POLISHED_REF_TMP,
+        ref_read_list=BIN_CLUSTER_REF_READ_LIST,
+        pol_reads_list=BIN_CLUSTER_POL_READS_LIST,
     output: BIN_CLUSTER_POLISHED_REF
-    params:
-        aln_clust_dir = BIN_CLUSTER_DIR
     conda: '../envs/python.yml'
     shell:
-        'python {SCRIPT_DIR}/rename_polished_genome.py -o {output} {input.fasta} '
-        '{params.aln_clust_dir}'
+        'python {SCRIPT_DIR}/rename_polished_genome.py -o {output} '
+        '{input.fasta} '
+        '{input.ref_read_list} '
+        '{input.pol_reads_list}'

--- a/rules/qc_genomes.smk
+++ b/rules/qc_genomes.smk
@@ -84,9 +84,9 @@ rule combine_dtr_aligns:
         cyc_perm_stats = temp(DTR_ALIGN_CYC_PERM_TSV)
     run:
         fns = list(str(i) for i in input)
-        print("DEBUG: Loading dtr alignment infos from " + repr(fns))
+        logger.debug("DEBUG: Loading dtr alignment infos from " + repr(fns))
         fns = expand_template_from_bin_clusters({}, DTR_ALIGN_TSV)
-        print("DEBUG: Loading dtr alignment infos from " + repr(fns))
+        logger.debug("DEBUG: Loading dtr alignment infos from " + repr(fns))
         df = pd.concat([pd.read_csv(fn, sep='\t') for fn in fns])
         print(df.shape)
         print(df.head())

--- a/rules/qc_genomes.smk
+++ b/rules/qc_genomes.smk
@@ -63,9 +63,6 @@ rule combine_bin_cluster_strand_counts_into_table:
         counts=temp(ALL_POL_STRANDS),
         annots=temp(ALL_POL_STRAND_ANNOTS)
     run:
-        import os
-        import pandas as pd
-        from glob import glob
         count_fns = glob(os.path.join(input.pol_dir, '*', '*.ref_read.strands.summary.tsv'))
         count_dfs = [pd.read_csv(fn, sep='\t') for fn in count_fns]
         count_df  = pd.concat(count_dfs)
@@ -84,9 +81,6 @@ rule combine_dtr_aligns:
     output: 
         cyc_perm_stats = temp(DTR_ALIGN_CYC_PERM_TSV)
     run:
-        import os
-        import pandas as pd
-        from glob import glob
         fns = glob(os.path.join(input.medaka_dir, '*', '*.dtr.aligns.tsv'))
         df = pd.concat([pd.read_csv(fn, sep='\t') for fn in fns])
         df['dtr_len'] = df['tend'] - df['tstart']
@@ -113,7 +107,6 @@ rule combine_all_draft_stats:
         cyc_perm_stats = DTR_ALIGN_CYC_PERM_TSV
     output: ALL_POL_STATS
     run:
-        import pandas as pd
         df_gc     = pd.read_csv(input.dtr_gc_stats, sep='\t').set_index('clust_id')
         df_cds    = pd.read_csv(input.cds_stats, sep='\t').set_index('clust_id')
         df_strand = pd.read_csv(input.strand_stats, sep='\t').set_index('clust_id')

--- a/rules/summary.smk
+++ b/rules/summary.smk
@@ -10,7 +10,6 @@ rule summary_stats:
     run:
         import matplotlib; matplotlib.use('Agg')
         import matplotlib.pyplot as plt
-        import numpy as np
         df = pd.read_csv(input.all_summary, quoting=3, sep='\t')
         
         # Sometimes these summary files have quotation marks around each row entry

--- a/rules/summary.smk
+++ b/rules/summary.smk
@@ -4,11 +4,10 @@
 
 rule summary_stats:
     input: 
-        all_summary = READS_IMPORT_SUMMARY
+        all_summary=READS_IMPORT_SUMMARY
     output:
         plot=SUMMARY_PLOT,
     run:
-        import pandas as pd
         import matplotlib; matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         import numpy as np

--- a/rules/virsorter.smk
+++ b/rules/virsorter.smk
@@ -28,16 +28,14 @@ rule virsorter_identify_phage:
         fasta=phage_fasta_files + prophage_fasta_files
     conda: '../envs/virsorter.yml'
     params:
-        output_dir=VIRSORTER_DIR,
-        db=config['VIRSORTER']['db'],
         virome="--virome" if config['VIRSORTER']['virome'] else "",
         diamond="--diamond" if config['VIRSORTER']['diamond'] else "",
     threads: config['max_threads']
     shell:
         'wrapper_phage_contigs_sorter_iPlant.pl -f {input} \
-         --wdir {params.output_dir} \
-         --data-dir {params.data_dir} \
-         --db {params.db} --ncpu {threads} \
+         --wdir {VIRSORTER_DIR} \
+         --data-dir {config[VIRSORTER][data_dir]} \
+         --db {config[VIRSORTER][db]} --ncpu {threads} \
          {params.virome} {params.diamond}'
 
 rule virsorter_collect_phage:

--- a/rules/virsorter.smk
+++ b/rules/virsorter.smk
@@ -1,0 +1,48 @@
+####################################
+# Identify phage reads in sample   #
+####################################
+
+# location of Virsorter output files
+phage_fasta_files = expand( \
+    "{dir}/Predicted_viral_sequences/VIRSorter_cat-{cat}.fasta", \
+    dir=VIRSORTER_DIR, \
+    cat=[1,2,3])
+prophage_fasta_files = expand( \
+    "{dir}/Predicted_viral_sequences/VIRSorter_vprophages_cat-{cat}.fasta", \
+    dir=VIRSORTER_DIR, \
+    cat=[4,5,6])
+
+# which sequences to return
+if config['VIRSORTER']['prophage']:
+    # return phage and prophage
+    fasta_list = phage_fasta_files + prophage_fasta_files
+else:
+    # return just the phage
+    fasta_list = phage_fasta_files
+
+rule virsorter_identify_phage:
+    """ Run VIRSORTER """
+    input: READS_IMPORT_FASTA
+    output:
+        table=VIRSORTER_DIR / "VIRSorter_global-phage-signal.csv",
+        fasta=phage_fasta_files + prophage_fasta_files
+    conda: '../envs/virsorter.yml'
+    params:
+        output_dir=VIRSORTER_DIR,
+        db=config['VIRSORTER']['db'],
+        virome="--virome" if config['VIRSORTER']['virome'] else "",
+        diamond="--diamond" if config['VIRSORTER']['diamond'] else "",
+    threads: config['max_threads']
+    shell:
+        'wrapper_phage_contigs_sorter_iPlant.pl -f {input} \
+         --wdir {params.output_dir} \
+         --data-dir {params.data_dir} \
+         --db {params.db} --ncpu {threads} \
+         {params.virome} {params.diamond}'
+
+rule virsorter_collect_phage:
+    """ Collect VIRSORTER output """
+    input: fasta_list
+    output:
+        fasta=VIRSORTER_FASTA
+    shell: 'cat {input} > {output}'

--- a/scripts/combine_cds_summary.py
+++ b/scripts/combine_cds_summary.py
@@ -10,8 +10,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     # Positional mandatory arguments
-    parser.add_argument('fns', nargs="+",  help='CDS stats files, one for each
-                        bin_cluster', type=str)
+    parser.add_argument('fns', nargs="+",  help='CDS stats files, one for each bin_cluster', type=str)
 
     # Optional arguments
     parser.add_argument('-o', '--output', help='Output file containing combined CDS statistics [cds.stats.combined.tsv]', type=str, default='cds.stats.combined.tsv')
@@ -22,6 +21,7 @@ def parse_args():
     return args
 
 def main(args):
+    print("DEBUG: " + repr(args.fns))
     df = pd.concat([pd.read_csv(fn, sep="\t").set_index("clust_id") \
                     for fn in args.fns], axis=0)
 

--- a/scripts/combine_cds_summary.py
+++ b/scripts/combine_cds_summary.py
@@ -10,7 +10,8 @@ def parse_args():
     parser = argparse.ArgumentParser()
 
     # Positional mandatory arguments
-    parser.add_argument('pol_dir', help='Path to directory containing the polished genomes and annotated CDS info for each alignment cluster', type=str)
+    parser.add_argument('fns', nargs="+",  help='CDS stats files, one for each
+                        bin_cluster', type=str)
 
     # Optional arguments
     parser.add_argument('-o', '--output', help='Output file containing combined CDS statistics [cds.stats.combined.tsv]', type=str, default='cds.stats.combined.tsv')
@@ -21,9 +22,8 @@ def parse_args():
     return args
 
 def main(args):
-    fns = glob(os.path.join(args.pol_dir, "*", "*.cds.stats.txt"))
-
-    df = pd.concat([pd.read_csv(fn, sep="\t").set_index("clust_id") for fn in fns], axis=0)
+    df = pd.concat([pd.read_csv(fn, sep="\t").set_index("clust_id") \
+                    for fn in args.fns], axis=0)
 
     df.reset_index().to_csv(args.output, sep="\t", index=False)
 

--- a/scripts/combine_cds_summary.py
+++ b/scripts/combine_cds_summary.py
@@ -21,7 +21,7 @@ def parse_args():
     return args
 
 def main(args):
-    print("DEBUG: cds inputs: " + repr(args.fns))
+    #print("DEBUG: cds inputs: " + repr(args.fns))
     df = pd.concat([pd.read_csv(fn, sep="\t").set_index("clust_id") \
                     for fn in args.fns], axis=0)
 

--- a/scripts/combine_cds_summary.py
+++ b/scripts/combine_cds_summary.py
@@ -21,7 +21,7 @@ def parse_args():
     return args
 
 def main(args):
-    print("DEBUG: " + repr(args.fns))
+    print("DEBUG: cds inputs: " + repr(args.fns))
     df = pd.concat([pd.read_csv(fn, sep="\t").set_index("clust_id") \
                     for fn in args.fns], axis=0)
 

--- a/scripts/rename_polished_genome.py
+++ b/scripts/rename_polished_genome.py
@@ -10,7 +10,8 @@ def parse_args():
 
     # Positional mandatory arguments
     parser.add_argument('fasta', help='Fasta file containing polished genome', type=str)
-    parser.add_argument('align_clust_dir', help='Directory containing subdirectories of read info for each alignment cluster', type=str)
+    parser.add_argument('ref_read_list', help='File with list of reference reads for the  cluster', type=str)
+    parser.add_argument('pol_reads_list', help='List of reads in  cluster', type=str)
 
     # Optional arguments
     parser.add_argument('-o', '--output', help='Output FASTA file [polished.renamed.fasta]', type=str, default='polished.renamed.fasta')
@@ -21,15 +22,18 @@ def parse_args():
     return args
 
 def get_clust_info(args, clust_id):
-    clust_dir = os.path.join(args.align_clust_dir, clust_id)
-    n_pols = pd.read_csv(os.path.join(clust_dir, '{}.pol_readlist.csv'.format(clust_id)), header=None).shape[0]
-    ref_read = open(os.path.join(clust_dir, '{}.ref_readlist.csv'.format(clust_id))).read().strip('\n')
-    return ref_read,n_pols
+    """ parse the read list csv file for cluster info """
+    # number of polishing reads
+    n_pols = len(open(args.pol_reads_list).readlines())
+    # reference read
+    ref_read = open(args.ref_read_list).readlines()[-1].strip()
+    return ref_read, n_pols
 
 def main(args):
+    # get the cluster ID from the path name
     clust_id = os.path.basename(args.fasta).split('.')[0]
 
-    ref_read,n_pols = get_clust_info(args, clust_id)
+    ref_read, n_pols = get_clust_info(args, clust_id)
 
     new_entry = []
     for Entry in SeqIO.parse(args.fasta, 'fasta'):


### PR DESCRIPTION
I replaced the use of dynamic() outputs with checkpoints. This gives us a couple advantages:

 * you can use the latest snakemake which supports the newer "conda activate" syntax
 * you can run the entire workflow in a single command

I also included a tweak that lets you skip the DTR finding or replace it with virsorter. The default config still uses DTR detection as the initial read filter. Let me know if you'd prefer a pull request without that addition.